### PR TITLE
Inline macros

### DIFF
--- a/lib/chunky_svg.ex
+++ b/lib/chunky_svg.ex
@@ -4,7 +4,13 @@ defmodule ChunkySVG do
   end
 
   def render(drawing) when is_list(drawing) do
-    drawing = drawing |> ChunkySVG.Macro.expand
-    {:svg, %{viewBox: "0 0 100 100", xmlns: "http://www.w3.org/2000/svg"}, drawing} |> XmlBuilder.generate
+    drawing = drawing |>
+      ChunkySVG.Builtin.expand |>
+      ChunkySVG.InlineMacro.expand
+    {
+      :svg,
+      %{viewBox: "0 0 100 100", xmlns: "http://www.w3.org/2000/svg"},
+      drawing
+    } |> XmlBuilder.generate
   end
 end

--- a/lib/chunky_svg.ex
+++ b/lib/chunky_svg.ex
@@ -1,24 +1,10 @@
 defmodule ChunkySVG do
-  def render(content) when is_tuple(content) do
-    render([content])
+  def render(drawing) when is_tuple(drawing) do
+    render([drawing])
   end
 
-  def render(content) when is_list(content) do
-    {:svg, %{viewBox: "0 0 100 100", xmlns: "http://www.w3.org/2000/svg"}, expand(content)} |> XmlBuilder.generate
-  end
-
-  defp expand({:hexagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(6, attributes)
-  defp expand({:octagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(8, attributes)
-  defp expand({:pentagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(5, attributes)
-
-  defp expand({:background, color}), do: {:rect, %{x: 0, y: 0, height: 100, width: 100, fill: color}, nil}
-  defp expand({:hills, attributes}), do: ChunkySVG.Hills.expand(attributes)
-
-  defp expand(list) when is_list(list) do
-    Enum.map(list, &expand/1)
-  end
-
-  defp expand(content) do
-    content
+  def render(drawing) when is_list(drawing) do
+    drawing = drawing |> ChunkySVG.Macro.expand
+    {:svg, %{viewBox: "0 0 100 100", xmlns: "http://www.w3.org/2000/svg"}, drawing} |> XmlBuilder.generate
   end
 end

--- a/lib/chunky_svg/builtin.ex
+++ b/lib/chunky_svg/builtin.ex
@@ -1,0 +1,12 @@
+defmodule ChunkySVG.Builtin do
+  def expand({:triangle, attributes}), do: ChunkySVG.Polygon.render_n_sided(3, attributes)
+  def expand({:hexagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(6, attributes)
+  def expand({:octagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(8, attributes)
+  def expand({:pentagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(5, attributes)
+  def expand({:background, color}), do: {:rect, %{x: 0, y: 0, height: 100, width: 100, fill: color}, nil}
+  def expand({:hills, attributes}), do: ChunkySVG.Hills.expand(attributes)
+  def expand(list) when is_list(list) do
+    Enum.map(list, &expand/1)
+  end
+  def expand(drawing), do: drawing # Pass Through Rule
+end

--- a/lib/chunky_svg/inline_macro.ex
+++ b/lib/chunky_svg/inline_macro.ex
@@ -1,19 +1,8 @@
-defmodule ChunkySVG.Macro do
+defmodule ChunkySVG.InlineMacro do
   def expand(drawing) do
-    inline_macros = extract_macros(drawing)
-    drawing |> inline(inline_macros) |> builtin
+    macros = extract_macros(drawing)
+    inline(drawing, macros)
   end
-
-  defp builtin({:triangle, attributes}), do: ChunkySVG.Polygon.render_n_sided(3, attributes)
-  defp builtin({:hexagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(6, attributes)
-  defp builtin({:octagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(8, attributes)
-  defp builtin({:pentagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(5, attributes)
-  defp builtin({:background, color}), do: {:rect, %{x: 0, y: 0, height: 100, width: 100, fill: color}, nil}
-  defp builtin({:hills, attributes}), do: ChunkySVG.Hills.expand(attributes)
-  defp builtin(list) when is_list(list) do
-    Enum.map(list, &builtin/1)
-  end
-  defp builtin(drawing), do: drawing # Pass Through Rule
 
   defp extract_macros({:def, label, shape}), do: [{label, shape}]
   defp extract_macros(drawing) when is_list(drawing) do

--- a/lib/chunky_svg/macro.ex
+++ b/lib/chunky_svg/macro.ex
@@ -24,11 +24,13 @@ defmodule ChunkySVG.Macro do
   defp inline(drawing, macros) when is_list(drawing) do
     Enum.map(drawing, &(inline(&1,macros))) |> Enum.filter(&(&1))
   end
-  defp inline({:def, _label, _shape}, macros), do: nil
+  defp inline({:def, _label, _shape}, _macros), do: nil
   defp inline({label}, macros) do
     case macros[label] do
       nil -> {label}
-      shape -> shape
+      {mlabel, mattributes, mcontents} ->
+        expanded_contents = inline(mcontents, macros)
+        {mlabel, mattributes, expanded_contents}
     end
   end
   defp inline({label, attributes}, macros) do
@@ -36,7 +38,8 @@ defmodule ChunkySVG.Macro do
       nil -> {label, attributes}
       {mlabel, mattributes, mcontents} ->
         merged_attributes = Dict.merge(mattributes, attributes)
-        {mlabel, merged_attributes, mcontents}
+        expanded_contents = inline(mcontents, macros)
+        {mlabel, merged_attributes, expanded_contents}
     end
   end
   defp inline(drawing, _macros), do: drawing

--- a/lib/chunky_svg/macro.ex
+++ b/lib/chunky_svg/macro.ex
@@ -31,5 +31,13 @@ defmodule ChunkySVG.Macro do
       shape -> shape
     end
   end
+  defp inline({label, attributes}, macros) do
+    case macros[label] do
+      nil -> {label, attributes}
+      {mlabel, mattributes, mcontents} ->
+        merged_attributes = Dict.merge(mattributes, attributes)
+        {mlabel, merged_attributes, mcontents}
+    end
+  end
   defp inline(drawing, _macros), do: drawing
 end

--- a/lib/chunky_svg/macro.ex
+++ b/lib/chunky_svg/macro.ex
@@ -1,0 +1,35 @@
+defmodule ChunkySVG.Macro do
+  def expand(drawing) do
+    inline_macros = extract_macros(drawing)
+    drawing |> inline(inline_macros) |> builtin
+  end
+
+  defp builtin({:triangle, attributes}), do: ChunkySVG.Polygon.render_n_sided(3, attributes)
+  defp builtin({:hexagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(6, attributes)
+  defp builtin({:octagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(8, attributes)
+  defp builtin({:pentagon, attributes}), do: ChunkySVG.Polygon.render_n_sided(5, attributes)
+  defp builtin({:background, color}), do: {:rect, %{x: 0, y: 0, height: 100, width: 100, fill: color}, nil}
+  defp builtin({:hills, attributes}), do: ChunkySVG.Hills.expand(attributes)
+  defp builtin(list) when is_list(list) do
+    Enum.map(list, &builtin/1)
+  end
+  defp builtin(drawing), do: drawing # Pass Through Rule
+
+  defp extract_macros({:def, label, shape}), do: [{label, shape}]
+  defp extract_macros(drawing) when is_list(drawing) do
+    Enum.map(drawing, &extract_macros/1) |> List.flatten
+  end
+  defp extract_macros(_), do: []
+
+  defp inline(drawing, macros) when is_list(drawing) do
+    Enum.map(drawing, &(inline(&1,macros))) |> Enum.filter(&(&1))
+  end
+  defp inline({:def, _label, _shape}, macros), do: nil
+  defp inline({label}, macros) do
+    case macros[label] do
+      nil -> {label}
+      shape -> shape
+    end
+  end
+  defp inline(drawing, _macros), do: drawing
+end

--- a/test/inline_macros_test.exs
+++ b/test/inline_macros_test.exs
@@ -7,7 +7,14 @@ defmodule InlineMacrosTest do
       {:def, :box, {:rect, %{x: 0, y: 0, height: 10, width: 10}, nil}},
       {:box},
     ]
-
     assert expand(drawing) == [{:rect, %{x: 0, y: 0, height: 10, width: 10}, nil}]
+  end
+
+  test "expands inline macros with merged attributes" do
+    drawing = [
+      {:def, :box, {:rect, %{x: 0, y: 0, height: 10, width: 10}, nil}},
+      {:box, %{transform: "rotate(45, 5, 5)"}},
+    ]
+    assert expand(drawing) == [{:rect, %{x: 0, y: 0, height: 10, width: 10, transform: "rotate(45, 5, 5)"}, nil}]
   end
 end

--- a/test/inline_macros_test.exs
+++ b/test/inline_macros_test.exs
@@ -1,0 +1,13 @@
+defmodule InlineMacrosTest do
+  use ExUnit.Case
+  import ChunkySVG.Macro
+
+  test "expands simple macros defined in the drawing" do
+    drawing = [
+      {:def, :box, {:rect, %{x: 0, y: 0, height: 10, width: 10}, nil}},
+      {:box},
+    ]
+
+    assert expand(drawing) == [{:rect, %{x: 0, y: 0, height: 10, width: 10}, nil}]
+  end
+end

--- a/test/inline_macros_test.exs
+++ b/test/inline_macros_test.exs
@@ -25,6 +25,24 @@ defmodule InlineMacrosTest do
         {:box, %{transform: "rotate(45, 3, 3)"}}
       ]}},
       {:box, %{transform: "rotate(45, 5, 5)"}},
+      {:box2}
+    ]
+
+    assert expand(drawing) == [
+      {:rect, %{height: 10, transform: "rotate(45, 5, 5)", width: 10, x: 0, y: 0}, nil},
+      {:rect, %{height: 4, width: 10, x: 1, y: 1}, [
+        {:rect, %{height: 10, transform: "rotate(45, 3, 3)", width: 10, x: 0, y: 0}, nil},
+      ]}
+    ]
+  end
+
+  test "can recursively inline macro with override attribues" do
+    drawing = [
+      {:def, :box, {:rect, %{x: 0, y: 0, height: 10, width: 10}, nil}},
+      {:def, :box2, {:rect, %{x: 1, y: 1, height: 4, width: 10}, [
+        {:box, %{transform: "rotate(45, 3, 3)"}}
+      ]}},
+      {:box, %{transform: "rotate(45, 5, 5)"}},
       {:box2, %{fill: "red"}}
     ]
 

--- a/test/inline_macros_test.exs
+++ b/test/inline_macros_test.exs
@@ -1,6 +1,6 @@
 defmodule InlineMacrosTest do
   use ExUnit.Case
-  import ChunkySVG.Macro
+  import ChunkySVG.InlineMacro
 
   test "expands simple macros defined in the drawing" do
     drawing = [

--- a/test/inline_macros_test.exs
+++ b/test/inline_macros_test.exs
@@ -17,4 +17,22 @@ defmodule InlineMacrosTest do
     ]
     assert expand(drawing) == [{:rect, %{x: 0, y: 0, height: 10, width: 10, transform: "rotate(45, 5, 5)"}, nil}]
   end
+
+  test "can recursively inline macro" do
+    drawing = [
+      {:def, :box, {:rect, %{x: 0, y: 0, height: 10, width: 10}, nil}},
+      {:def, :box2, {:rect, %{x: 1, y: 1, height: 4, width: 10}, [
+        {:box, %{transform: "rotate(45, 3, 3)"}}
+      ]}},
+      {:box, %{transform: "rotate(45, 5, 5)"}},
+      {:box2, %{fill: "red"}}
+    ]
+
+    assert expand(drawing) == [
+      {:rect, %{height: 10, transform: "rotate(45, 5, 5)", width: 10, x: 0, y: 0}, nil},
+      {:rect, %{height: 4, width: 10, x: 1, y: 1, fill: "red"}, [
+        {:rect, %{height: 10, transform: "rotate(45, 3, 3)", width: 10, x: 0, y: 0}, nil},
+      ]}
+    ]
+  end
 end


### PR DESCRIPTION
Support for defining macros inside of a drawing definition like this:

``` elixir
[
  {:def, :box, {:rect, %{x: 0, y: 0, width: 10, height: 10}, nil}},
  {:box},
  {:box, %{fill: red}}
]
```

/cc @film42

Does this implementation look reasonable?
