### PR TITLE
fix compiler warnings

### DIFF
--- a/lib/chunky_svg/hills.ex
+++ b/lib/chunky_svg/hills.ex
@@ -1,10 +1,10 @@
 defmodule ChunkySVG.Hills do
   def expand(attributes) do
     %{points: points} = attributes
-    bez_points = [{0,100} | points] |> ChunkySVG.Cons.each_cons |> Enum.map fn([{x1,y1},{x2,y2}]) ->
+    bez_points = [{0,100} | points] |> ChunkySVG.Cons.each_cons |> Enum.map(fn([{x1,y1},{x2,y2}]) ->
       [{x1 + ((x2-x1)/2), Enum.min([y1,y2])},{x2,y2}]
-    end
-    bez_points = bez_points |> List.flatten |> Enum.map fn ({x,y}) -> "#{x},#{y}" end
+    end)
+    bez_points = bez_points |> List.flatten |> Enum.map(fn ({x,y}) -> "#{x},#{y}" end)
     bez_points = bez_points |> Enum.join(" ")
     path_spec = "M0,100 Q#{bez_points} L100,100 z"
     attributes = attributes |> Dict.drop([:points]) |> Dict.put(:d, path_spec)

--- a/lib/chunky_svg/polygon.ex
+++ b/lib/chunky_svg/polygon.ex
@@ -2,10 +2,10 @@ defmodule ChunkySVG.Polygon do
   def render_n_sided(n, attributes) when n > 2 do
     %{r: r, cx: cx, cy: cy} = attributes
     theta = (2 * :math.pi) / n
-    angles = (0..n-1) |> Enum.map fn (n) -> theta * n end
-    points = angles |> Enum.map fn (angle) ->
+    angles = (0..n-1) |> Enum.map(fn (n) -> theta * n end)
+    points = angles |> Enum.map(fn (angle) ->
       [cx + r * :math.sin(angle), cy + r * :math.cos(angle) ]
-    end
+    end)
     points = points |> List.flatten |> Enum.map(&Float.to_string/1) |> Enum.join(" ")
     attributes = attributes |> Dict.drop([:r, :cx, :cy]) |> Dict.put(:points, points)
     {:polygon, attributes, nil}

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,1 @@
-%{"xml_builder": {:hex, :xml_builder, "0.0.5"}}
+%{"xml_builder": {:hex, :xml_builder, "0.0.5", "fa1d7577974a2fb21835bc841df5e7e54586d461179b56259c651751508b892d", [:mix], []}}

--- a/test/polygon_test.exs
+++ b/test/polygon_test.exs
@@ -23,9 +23,9 @@ defmodule PolygonTest do
     len = String.length(str)
     string_of_numbers = str |> String.slice(81, len - 81 - 10)
     numbers = string_of_numbers |> String.split(" ") |> Enum.map(&String.to_float/1)
-    Enum.zip(numbers, reference_numbers) |> Enum.each fn ({number, reference}) ->
+    Enum.zip(numbers, reference_numbers) |> Enum.each(fn ({number, reference}) ->
       assert_in_delta number, reference, 0.1
-    end
+    end)
   end
 
   def starts_with_svg_header(str) do


### PR DESCRIPTION
Under elixir 1.2+ leaving off parentheses of a function call in a pipeline is considered ambiguous and it generates a compiler warning. This PR cleans up a few cases of this in `chunky_svg`.
