### PR TITLE
update travis versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: elixir
 otp_release:
- - 17.1
- - 17.4
+ - 18.2.1
+ - 19.0.2
 elixir:
- - 1.0
+ - 1.2
+ - 1.3


### PR DESCRIPTION
Just noticed in #13 that we were building on elixir 1.0 and erlang 17.X versions. This updates to use erlang 18 and 19 with elixir 1.2 and 1.3.
